### PR TITLE
Add metadata to create .cab files for the LVFS

### DIFF
--- a/RQR12/RQR12.05/lvfs/Makefile
+++ b/RQR12/RQR12.05/lvfs/Makefile
@@ -1,0 +1,18 @@
+# Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
+
+VENDOR=Logitech
+PROJECT_NAME=Unifying
+VERSION=RQR12.05_B0028
+FIRMWARE_FILES=../RQR12.05_B0028.hex
+METAINFO_FILES=com.logitech.Unifying.RQR12.metainfo.xml
+
+all: $(VENDOR)-$(PROJECT_NAME)-$(VERSION).cab
+
+clean:
+	rm *.cab
+
+check: $(METAINFO_FILES)
+	appstream-util validate-relax $(METAINFO_FILES)
+
+%.cab: $(FIRMWARE_FILES) $(METAINFO_FILES)
+	gcab --create --nopath $@ $(FIRMWARE_FILES) $(METAINFO_FILES)

--- a/RQR12/RQR12.05/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.05/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2017 Richard Hughes <richard@hughsie.com> -->
+<component type="firmware">
+  <id>com.logitech.Unifying.RQR12.firmware</id>
+  <name>Unifying</name>
+  <summary>Firmware for the Logitech Unifying receiver</summary>
+  <description>
+    <p>
+      A Unifying receiver allows you to connect multiple compatible keyboards
+      and mice to a laptop or desktop computer with a single USB receiver.
+      Updating the firmware on your Unifying receiver improves performance, adds
+      new features and fixes security issues.
+    </p>
+  </description>
+  <provides>
+    <!-- USB\VID_046D&PID_AAAA -->
+    <firmware type="flashed">9d131a0c-a606-580f-8eda-80587250b8d6</firmware>
+  </provides>
+  <url type="homepage">http://support.logitech.com/en-us/software/unifying</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>Proprietary</project_license>
+  <developer_name>Logitech</developer_name>
+  <releases>
+    <release urgency="high" version="RQR12.07_B0029" date="2017-05-02">
+      <checksum filename="RQR12.05_B0028.hex" target="content"/>
+      <description>
+        <p>
+          This release addresses an force pairing issue, an unencrypted
+          keystroke injection issue and fake mouse issue known as Bastille
+          security issues #1, #2 and #3.
+          The vulnerabilities are complex to replicate and would require a hacker
+          to be physically close to a target.
+        </p>
+      </description>
+    </release>
+  </releases>
+
+  <!-- only newer versions of fwupd know how to write to this hardware -->
+  <requires>
+    <id compare="ge" version="0.9.2">org.freedesktop.fwupd</id>
+    <firmware compare="regex" version="BOT01.0[0-3]_*">bootloader</firmware>
+  </requires>
+
+</component>

--- a/RQR12/RQR12.07/lvfs/Makefile
+++ b/RQR12/RQR12.07/lvfs/Makefile
@@ -1,0 +1,18 @@
+# Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
+
+VENDOR=Logitech
+PROJECT_NAME=Unifying
+VERSION=RQR12.07_B0029
+FIRMWARE_FILES=../RQR12.07_B0029.hex
+METAINFO_FILES=com.logitech.Unifying.RQR12.metainfo.xml
+
+all: $(VENDOR)-$(PROJECT_NAME)-$(VERSION).cab
+
+clean:
+	rm *.cab
+
+check: $(METAINFO_FILES)
+	appstream-util validate-relax $(METAINFO_FILES)
+
+%.cab: $(FIRMWARE_FILES) $(METAINFO_FILES)
+	gcab --create --nopath $@ $(FIRMWARE_FILES) $(METAINFO_FILES)

--- a/RQR12/RQR12.07/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.07/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2017 Richard Hughes <richard@hughsie.com> -->
+<component type="firmware">
+  <id>com.logitech.Unifying.RQR12.firmware</id>
+  <name>Unifying</name>
+  <summary>Firmware for the Logitech Unifying receiver</summary>
+  <description>
+    <p>
+      A Unifying receiver allows you to connect multiple compatible keyboards
+      and mice to a laptop or desktop computer with a single USB receiver.
+      Updating the firmware on your Unifying receiver improves performance, adds
+      new features and fixes security issues.
+    </p>
+  </description>
+  <provides>
+    <!-- USB\VID_046D&PID_AAAA -->
+    <firmware type="flashed">9d131a0c-a606-580f-8eda-80587250b8d6</firmware>
+  </provides>
+  <url type="homepage">http://support.logitech.com/en-us/software/unifying</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>Proprietary</project_license>
+  <developer_name>Logitech</developer_name>
+  <releases>
+    <release urgency="high" version="RQR12.07_B0029" date="2017-05-03">
+      <checksum filename="RQR12.07_B0029.hex" target="content"/>
+      <description>
+        <p>
+          This release addresses an unencrypted keystroke injection issue known
+          as Bastille security issue #11.
+          The vulnerability is complex to replicate and would require a hacker
+          to be physically close to a target.
+        </p>
+      </description>
+    </release>
+  </releases>
+
+  <!-- only newer versions of fwupd know how to write to this hardware -->
+  <requires>
+    <id compare="ge" version="0.9.2">org.freedesktop.fwupd</id>
+    <firmware compare="regex" version="BOT01.0[0-3]_*">bootloader</firmware>
+  </requires>
+
+</component>

--- a/RQR24/RQR24.03/lvfs/Makefile
+++ b/RQR24/RQR24.03/lvfs/Makefile
@@ -1,0 +1,18 @@
+# Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
+
+VENDOR=Logitech
+PROJECT_NAME=Unifying
+VERSION=RQ024.03_B0027
+FIRMWARE_FILES=../RQR24.03_B0027.hex
+METAINFO_FILES=com.logitech.Unifying.RQR24.metainfo.xml
+
+all: $(VENDOR)-$(PROJECT_NAME)-$(VERSION).cab
+
+clean:
+	rm *.cab
+
+check: $(METAINFO_FILES)
+	appstream-util validate-relax $(METAINFO_FILES)
+
+%.cab: $(FIRMWARE_FILES) $(METAINFO_FILES)
+	gcab --create --nopath $@ $(FIRMWARE_FILES) $(METAINFO_FILES)

--- a/RQR24/RQR24.03/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.03/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2017 Richard Hughes <richard@hughsie.com> -->
+<component type="firmware">
+  <id>com.logitech.Unifying.RQR24.firmware</id>
+  <name>Unifying</name>
+  <summary>Firmware for the Logitech Unifying receiver</summary>
+  <description>
+    <p>
+      A Unifying receiver allows you to connect multiple compatible keyboards
+      and mice to a laptop or desktop computer with a single USB receiver.
+      Updating the firmware on your Unifying receiver improves performance, adds
+      new features and fixes security issues.
+    </p>
+  </description>
+  <provides>
+    <!-- USB\VID_046D&PID_AAAC -->
+    <firmware type="flashed">cc4cbfa9-bf9d-540b-b92b-172ce31013c1</firmware>
+  </provides>
+  <url type="homepage">http://support.logitech.com/en-us/software/unifying</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>Proprietary</project_license>
+  <developer_name>Logitech</developer_name>
+  <releases>
+    <release urgency="high" version="RQR24.03_B0027" date="2017-05-02">
+      <checksum filename="RQR24.03_B0027.hex" target="content"/>
+      <description>
+        <p>
+          This release addresses an unencrypted keystroke injection issue and
+          fake mouse issue known as Bastille security issues #2 and #3.
+          The vulnerabilities are complex to replicate and would require a hacker
+          to be physically close to a target.
+        </p>
+      </description>
+    </release>
+  </releases>
+
+  <!-- only newer versions of fwupd know how to write to this hardware -->
+  <requires>
+    <id compare="ge" version="0.9.2">org.freedesktop.fwupd</id>
+    <firmware compare="regex" version="BOT03.0[0-1]_*">bootloader</firmware>
+  </requires>
+
+</component>

--- a/RQR24/RQR24.05/lvfs/Makefile
+++ b/RQR24/RQR24.05/lvfs/Makefile
@@ -1,0 +1,18 @@
+# Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
+
+VENDOR=Logitech
+PROJECT_NAME=Unifying
+VERSION=RQR24.05_B0029
+FIRMWARE_FILES=../RQR24.05_B0029.hex
+METAINFO_FILES=com.logitech.Unifying.RQR24.metainfo.xml
+
+all: $(VENDOR)-$(PROJECT_NAME)-$(VERSION).cab
+
+clean:
+	rm *.cab
+
+check: $(METAINFO_FILES)
+	appstream-util validate-relax $(METAINFO_FILES)
+
+%.cab: $(FIRMWARE_FILES) $(METAINFO_FILES)
+	gcab --create --nopath $@ $(FIRMWARE_FILES) $(METAINFO_FILES)

--- a/RQR24/RQR24.05/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.05/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2017 Richard Hughes <richard@hughsie.com> -->
+<component type="firmware">
+  <id>com.logitech.Unifying.RQR24.firmware</id>
+  <name>Unifying</name>
+  <summary>Firmware for the Logitech Unifying receiver</summary>
+  <description>
+    <p>
+      A Unifying receiver allows you to connect multiple compatible keyboards
+      and mice to a laptop or desktop computer with a single USB receiver.
+      Updating the firmware on your Unifying receiver improves performance, adds
+      new features and fixes security issues.
+    </p>
+  </description>
+  <provides>
+    <!-- USB\VID_046D&PID_AAAC -->
+    <firmware type="flashed">cc4cbfa9-bf9d-540b-b92b-172ce31013c1</firmware>
+  </provides>
+  <url type="homepage">http://support.logitech.com/en-us/software/unifying</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>Proprietary</project_license>
+  <developer_name>Logitech</developer_name>
+  <releases>
+    <release urgency="high" version="RQR24.05_B0029" date="2017-05-03">
+      <checksum filename="RQR24.05_B0029.hex" target="content"/>
+      <description>
+        <p>
+          This release addresses an unencrypted keystroke injection issue known
+          as Bastille security issue #11.
+          The vulnerability is complex to replicate and would require a hacker
+          to be physically close to a target.
+        </p>
+      </description>
+    </release>
+  </releases>
+
+  <!-- only newer versions of fwupd know how to write to this hardware -->
+  <requires>
+    <id compare="ge" version="0.8.2">org.freedesktop.fwupd</id>
+    <firmware compare="regex" version="BOT03.0[0-1]_*">bootloader</firmware>
+  </requires>
+
+</component>


### PR DESCRIPTION
This will create files of the format Logitech-Unifying-RQR024.005_B00029.cab

Signed-off-by: Richard Hughes <richard@hughsie.com>