### PR TITLE
RQR12.05, build 0028, fix metadata version

### DIFF
--- a/RQR12/RQR12.05/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.05/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -21,7 +21,7 @@
   <project_license>Proprietary</project_license>
   <developer_name>Logitech</developer_name>
   <releases>
-    <release urgency="high" version="RQR12.07_B0029" date="2017-05-02">
+    <release urgency="high" version="RQR12.05_B0028" date="2017-05-02">
       <checksum filename="RQR12.05_B0028.hex" target="content"/>
       <description>
         <p>


### PR DESCRIPTION
Wrong metadata version was preventing upload to lvfs