### PR TITLE
(RQR12/24) Fix license case and explain GUIDs in comment

### DIFF
--- a/MPK01/MPK01.02/lvfs/com.logitech.MPK01.metainfo.xml
+++ b/MPK01/MPK01.02/lvfs/com.logitech.MPK01.metainfo.xml
@@ -15,7 +15,7 @@
   </provides>
   <url type="homepage">http://www.logitech.com/en-us/product/k780-multi-device-wireless-keyboard</url>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>Proprietary</project_license>
+  <project_license>LicenseRef-proprietary</project_license>
   <developer_name>Logitech</developer_name>
   <releases>
     <release urgency="high" version="MPK01.02_B0021" date="2017-06-16">

--- a/MPK01/MPK01.03/lvfs/com.logitech.MPK01.metainfo.xml
+++ b/MPK01/MPK01.03/lvfs/com.logitech.MPK01.metainfo.xml
@@ -15,7 +15,7 @@
   </provides>
   <url type="homepage">http://www.logitech.com/en-us/product/k780-multi-device-wireless-keyboard</url>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>Proprietary</project_license>
+  <project_license>LicenseRef-proprietary</project_license>
   <developer_name>Logitech</developer_name>
   <releases>
     <release urgency="high" version="MPK01.03_B0024" date="2017-06-16">

--- a/RQR12/RQR12.05/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.05/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -12,6 +12,8 @@
       new features and fixes security issues.
     </p>
   </description>
+  <!-- Signed/unsigned versions are split into different components to permit
+       having different <requires> on each even though they share GUIDs -->
   <provides>
     <!-- USB\VID_046D&PID_AAAA -->
     <firmware type="flashed">9d131a0c-a606-580f-8eda-80587250b8d6</firmware>
@@ -20,7 +22,7 @@
   </provides>
   <url type="homepage">http://support.logitech.com/en-us/software/unifying</url>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>Proprietary</project_license>
+  <project_license>LicenseRef-proprietary</project_license>
   <developer_name>Logitech</developer_name>
   <releases>
     <release urgency="high" version="RQR12.05_B0028" date="2017-05-02">

--- a/RQR12/RQR12.07/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.07/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -12,15 +12,18 @@
       new features and fixes security issues.
     </p>
   </description>
+  <!-- Signed/unsigned versions are split into different components to permit
+       having different <requires> on each even though they share GUIDs -->
   <provides>
     <!-- USB\VID_046D&PID_AAAA -->
     <firmware type="flashed">9d131a0c-a606-580f-8eda-80587250b8d6</firmware>
+
     <!-- USB\VID_046D&PID_AAAE -->
     <firmware type="flashed">d637baf7-3ab5-502a-8169-2545302e44e2</firmware>
   </provides>
   <url type="homepage">http://support.logitech.com/en-us/software/unifying</url>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>Proprietary</project_license>
+  <project_license>LicenseRef-proprietary</project_license>
   <developer_name>Logitech</developer_name>
   <releases>
     <release urgency="high" version="RQR12.07_B0029" date="2017-05-03">

--- a/RQR24/RQR24.03/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.03/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -12,6 +12,8 @@
       new features and fixes security issues.
     </p>
   </description>
+  <!-- Signed/unsigned versions are split into different components to permit
+       having different <requires> on each even though they share GUIDs -->
   <provides>
     <!-- USB\VID_046D&PID_AAAC -->
     <firmware type="flashed">cc4cbfa9-bf9d-540b-b92b-172ce31013c1</firmware>
@@ -20,7 +22,7 @@
   </provides>
   <url type="homepage">http://support.logitech.com/en-us/software/unifying</url>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>Proprietary</project_license>
+  <project_license>LicenseRef-proprietary</project_license>
   <developer_name>Logitech</developer_name>
   <releases>
     <release urgency="high" version="RQR24.03_B0027" date="2017-05-02">

--- a/RQR24/RQR24.05/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.05/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -12,6 +12,8 @@
       new features and fixes security issues.
     </p>
   </description>
+  <!-- Signed/unsigned versions are split into different components to permit
+       having different <requires> on each even though they share GUIDs -->
   <provides>
     <!-- USB\VID_046D&PID_AAAC -->
     <firmware type="flashed">cc4cbfa9-bf9d-540b-b92b-172ce31013c1</firmware>
@@ -20,7 +22,7 @@
   </provides>
   <url type="homepage">http://support.logitech.com/en-us/software/unifying</url>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>Proprietary</project_license>
+  <project_license>LicenseRef-proprietary</project_license>
   <developer_name>Logitech</developer_name>
   <releases>
     <release urgency="high" version="RQR24.05_B0029" date="2017-05-03">


### PR DESCRIPTION
It seems we do not need need additionnal GUIDs since it is possible to split the signed/unsigned variant in two separate components (each with its own constraints on bootloader version). This will require a small patch in fwupd though.

Signed-off-by: Ogier Bouvier <obouvier@logitech.com>