### PR TITLE
Update metadata for license and fwupd version requirements

### DIFF
--- a/MPK01/MPK01.03/lvfs/com.logitech.MPK01.metainfo.xml
+++ b/MPK01/MPK01.03/lvfs/com.logitech.MPK01.metainfo.xml
@@ -15,7 +15,7 @@
   </provides>
   <url type="homepage">http://www.logitech.com/en-us/product/k780-multi-device-wireless-keyboard</url>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>Proprietary</project_license>
+  <project_license>LicenseRef-proprietary</project_license>
   <developer_name>Logitech</developer_name>
   <releases>
     <release urgency="high" version="MPK01.03_B0024" date="2017-06-16">

--- a/MPK03/MPK03.02/lvfs/com.logitech.MPK03.metainfo.xml
+++ b/MPK03/MPK03.02/lvfs/com.logitech.MPK03.metainfo.xml
@@ -16,7 +16,7 @@
   </provides>
   <url type="homepage">http://www.logitech.com/en-us/product/k375s-multidevice-keyboard</url>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>Proprietary</project_license>
+  <project_license>LicenseRef-proprietary</project_license>
   <developer_name>Logitech</developer_name>
   <releases>
     <release urgency="high" version="MPK03.02_B0009" date="2017-06-26">

--- a/MPK04/MPK04.01/lvfs/com.logitech.MPK04.metainfo.xml
+++ b/MPK04/MPK04.01/lvfs/com.logitech.MPK04.metainfo.xml
@@ -15,7 +15,7 @@
   </provides>
   <url type="homepage">http://www.logitech.com/en-us/product/mk850-wireless-keyboard-mouse-combo</url>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>Proprietary</project_license>
+  <project_license>LicenseRef-proprietary</project_license>
   <developer_name>Logitech</developer_name>
   <releases>
     <release urgency="high" version="MPK04.01_B0010" date="2017-06-26">

--- a/RQK62/RQK62.01/lvfs/com.logitech.RQK62.metainfo.xml
+++ b/RQK62/RQK62.01/lvfs/com.logitech.RQK62.metainfo.xml
@@ -30,9 +30,9 @@
     </release>
   </releases>
 
-  <!-- only newer versions of fwupd know how to write to this hardware -->
+  <!-- This requires the version of fwupd that supports manual restart of device -->
   <requires>
-    <id compare="ge" version="0.9.5">org.freedesktop.fwupd</id>
+    <id compare="ge" version="1.0.3">org.freedesktop.fwupd</id>
   </requires>
 
 </component>

--- a/RQK62/RQK62.01/lvfs/com.logitech.RQK62.metainfo.xml
+++ b/RQK62/RQK62.01/lvfs/com.logitech.RQK62.metainfo.xml
@@ -15,7 +15,7 @@
   </provides>
   <url type="homepage">http://www.logitech.com/en-us/product/living-room-keyboard-k830</url>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>Proprietary</project_license>
+  <project_license>LicenseRef-proprietary</project_license>
   <developer_name>Logitech</developer_name>
   <releases>
     <release urgency="high" version="RQK62.01_B0014" date="2017-06-26">

--- a/RQK63/RQK63.02/lvfs/com.logitech.RQK63.metainfo.xml
+++ b/RQK63/RQK63.02/lvfs/com.logitech.RQK63.metainfo.xml
@@ -15,7 +15,7 @@
   </provides>
   <url type="homepage">http://www.logitech.com/en-us/product/wireless-touch-keyboard-k400-plus</url>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>Proprietary</project_license>
+  <project_license>LicenseRef-proprietary</project_license>
   <developer_name>Logitech</developer_name>
   <releases>
     <release urgency="high" version="RQK63.02_B0016" date="2017-06-26">

--- a/RQR12/RQR12.08/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.08/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -20,7 +20,7 @@
   </provides>
   <url type="homepage">http://support.logitech.com/en-us/software/unifying</url>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>Proprietary</project_license>
+  <project_license>LicenseRef-proprietary</project_license>
   <developer_name>Logitech</developer_name>
   <releases>
     <release urgency="high" version="RQR12.08_B0030" date="2017-06-26">

--- a/RQR12/RQR12.09/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.09/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2017 Logitech -->
 <component type="firmware">
-  <id>com.logitech.Unifying.RQR12.firmware</id>
+  <id>com.logitech.Unifying.RQR12.signed.firmware</id>
   <name>Logitech Unifying Receiver</name>
   <summary>Firmware for the Logitech Unifying receiver</summary>
   <description>
@@ -32,9 +32,9 @@
     </release>
   </releases>
 
-  <!-- only newer versions of fwupd know how to write to this hardware -->
+  <!-- requires fwupd version that knows how to write signed firmware -->
   <requires>
-    <id compare="ge" version="0.9.5">org.freedesktop.fwupd</id>
+    <id compare="ge" version="1.0.3">org.freedesktop.fwupd</id>
     <firmware compare="regex" version="BOT01.0[4-9]_*">bootloader</firmware>
   </requires>
 

--- a/RQR12/RQR12.09/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.09/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -19,7 +19,7 @@
   </provides>
   <url type="homepage">http://support.logitech.com/en-us/software/unifying</url>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>Proprietary</project_license>
+  <project_license>LicenseRef-proprietary</project_license>
   <developer_name>Logitech</developer_name>
   <releases>
     <release urgency="high" version="RQR12.09_B0030" date="2017-06-26">

--- a/RQR24/RQR24.06/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.06/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -20,7 +20,7 @@
   </provides>
   <url type="homepage">http://support.logitech.com/en-us/software/unifying</url>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>Proprietary</project_license>
+  <project_license>LicenseRef-proprietary</project_license>
   <developer_name>Logitech</developer_name>
   <releases>
     <release urgency="high" version="RQR24.06_B0030" date="2017-06-26">

--- a/RQR24/RQR24.07/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.07/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -19,7 +19,7 @@
   </provides>
   <url type="homepage">http://support.logitech.com/en-us/software/unifying</url>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>Proprietary</project_license>
+  <project_license>LicenseRef-proprietary</project_license>
   <developer_name>Logitech</developer_name>
   <releases>
     <release urgency="high" version="RQR24.07_B0030" date="2017-06-26">

--- a/RQR24/RQR24.07/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.07/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2017 Logitech -->
 <component type="firmware">
-  <id>com.logitech.Unifying.RQR24.firmware</id>
+  <id>com.logitech.Unifying.RQR24.signed.firmware</id>
   <name>Logitech Unifying Receiver</name>
   <summary>Firmware for the Logitech Unifying receiver</summary>
   <description>
@@ -32,9 +32,9 @@
     </release>
   </releases>
 
-  <!-- only newer versions of fwupd know how to write to this hardware -->
+  <!-- requires fwupd version that knows how to write signed firmware -->
   <requires>
-    <id compare="ge" version="0.9.5">org.freedesktop.fwupd</id>
+    <id compare="ge" version="1.0.3">org.freedesktop.fwupd</id>
     <firmware compare="regex" version="BOT03.0[2-9]_*">bootloader</firmware>
   </requires>
 


### PR DESCRIPTION
This updates the version requirements where needed (signed firmwares and manual reset devices) and fixes the license case. 