### PR TITLE
RQR12, RQR24, list incompatibilities in meta-data

### DIFF
--- a/RQR12/RQR12.08/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.08/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -50,13 +50,6 @@
           firmware.
         </p>
       </description>
-      <incompatibilities>
-        <firmware compare="regex" version="RQK62.00_*">paired device</firmware>
-        <firmware compare="regex" version="RQK63.0[01]_*">paired device</firmware>
-        <firmware compare="regex" version="MPK01.0[0-2]_*">paired device</firmware>
-        <firmware compare="regex" version="MPK03.0[0-1]_*">paired device</firmware>
-        <firmware compare="regex" version="MPK04.00_*">paired device</firmware>
-      </incompatibilities>
     </release>
   </releases>
 
@@ -64,6 +57,11 @@
   <requires>
     <id compare="ge" version="0.9.5">org.freedesktop.fwupd</id>
     <firmware compare="regex" version="BOT01.0[0-3]_*">bootloader</firmware>
+    <firmware compare="regex" version="RQK62.00_*">not-child</firmware>
+    <firmware compare="regex" version="RQK63.0[01]_*">not-child</firmware>
+    <firmware compare="regex" version="MPK01.0[0-2]_*">not-child</firmware>
+    <firmware compare="regex" version="MPK03.0[0-1]_*">not-child</firmware>
+    <firmware compare="regex" version="MPK04.00_*">not-child</firmware>
   </requires>
 
 </component>

--- a/RQR12/RQR12.08/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.08/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -50,6 +50,13 @@
           firmware.
         </p>
       </description>
+      <incompatibilities>
+        <firmware compare="regex" version="RQK62.00_*">paired device</firmware>
+        <firmware compare="regex" version="RQK63.0[01]_*">paired device</firmware>
+        <firmware compare="regex" version="MPK01.0[0-2]_*">paired device</firmware>
+        <firmware compare="regex" version="MPK03.0[0-1]_*">paired device</firmware>
+        <firmware compare="regex" version="MPK04.00_*">paired device</firmware>
+      </incompatibilities>
     </release>
   </releases>
 

--- a/RQR12/RQR12.09/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.09/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -29,6 +29,13 @@
           First release for signed DFU, otherwise identical to RQR12.08_B0030.
         </p>
       </description>
+      <incompatibilities>
+        <firmware compare="regex" version="RQK62.00_*">paired device</firmware>
+        <firmware compare="regex" version="RQK63.0[01]_*">paired device</firmware>
+        <firmware compare="regex" version="MPK01.0[0-2]_*">paired device</firmware>
+        <firmware compare="regex" version="MPK03.0[0-1]_*">paired device</firmware>
+        <firmware compare="regex" version="MPK04.00_*">paired device</firmware>
+      </incompatibilities>
     </release>
   </releases>
 

--- a/RQR12/RQR12.09/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.09/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -29,13 +29,6 @@
           First release for signed DFU, otherwise identical to RQR12.08_B0030.
         </p>
       </description>
-      <incompatibilities>
-        <firmware compare="regex" version="RQK62.00_*">paired device</firmware>
-        <firmware compare="regex" version="RQK63.0[01]_*">paired device</firmware>
-        <firmware compare="regex" version="MPK01.0[0-2]_*">paired device</firmware>
-        <firmware compare="regex" version="MPK03.0[0-1]_*">paired device</firmware>
-        <firmware compare="regex" version="MPK04.00_*">paired device</firmware>
-      </incompatibilities>
     </release>
   </releases>
 
@@ -43,6 +36,11 @@
   <requires>
     <id compare="ge" version="1.0.3">org.freedesktop.fwupd</id>
     <firmware compare="regex" version="BOT01.0[4-9]_*">bootloader</firmware>
+    <firmware compare="regex" version="RQK62.00_*">not-child</firmware>
+    <firmware compare="regex" version="RQK63.0[01]_*">not-child</firmware>
+    <firmware compare="regex" version="MPK01.0[0-2]_*">not-child</firmware>
+    <firmware compare="regex" version="MPK03.0[0-1]_*">not-child</firmware>
+    <firmware compare="regex" version="MPK04.00_*">not-child</firmware>
   </requires>
 
 </component>

--- a/RQR24/RQR24.06/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.06/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -50,6 +50,13 @@
           firmware.
         </p>
       </description>
+      <incompatibilities>
+        <firmware compare="regex" version="RQK62.00_*">paired device</firmware>
+        <firmware compare="regex" version="RQK63.0[01]_*">paired device</firmware>
+        <firmware compare="regex" version="MPK01.0[0-2]_*">paired device</firmware>
+        <firmware compare="regex" version="MPK03.0[0-1]_*">paired device</firmware>
+        <firmware compare="regex" version="MPK04.00_*">paired device</firmware>
+      </incompatibilities>
     </release>
   </releases>
 

--- a/RQR24/RQR24.06/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.06/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -50,13 +50,6 @@
           firmware.
         </p>
       </description>
-      <incompatibilities>
-        <firmware compare="regex" version="RQK62.00_*">paired device</firmware>
-        <firmware compare="regex" version="RQK63.0[01]_*">paired device</firmware>
-        <firmware compare="regex" version="MPK01.0[0-2]_*">paired device</firmware>
-        <firmware compare="regex" version="MPK03.0[0-1]_*">paired device</firmware>
-        <firmware compare="regex" version="MPK04.00_*">paired device</firmware>
-      </incompatibilities>
     </release>
   </releases>
 
@@ -64,6 +57,11 @@
   <requires>
     <id compare="ge" version="0.9.5">org.freedesktop.fwupd</id>
     <firmware compare="regex" version="BOT03.0[0-1]_*">bootloader</firmware>
+    <firmware compare="regex" version="RQK62.00_*">not-child</firmware>
+    <firmware compare="regex" version="RQK63.0[01]_*">not-child</firmware>
+    <firmware compare="regex" version="MPK01.0[0-2]_*">not-child</firmware>
+    <firmware compare="regex" version="MPK03.0[0-1]_*">not-child</firmware>
+    <firmware compare="regex" version="MPK04.00_*">not-child</firmware>
   </requires>
 
 </component>

--- a/RQR24/RQR24.07/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.07/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -29,13 +29,6 @@
           First release for signed DFU, otherwise identical to RQR24.06_B0030.
         </p>
       </description>
-      <incompatibilities>
-        <firmware compare="regex" version="RQK62.00_*">paired device</firmware>
-        <firmware compare="regex" version="RQK63.0[01]_*">paired device</firmware>
-        <firmware compare="regex" version="MPK01.0[0-2]_*">paired device</firmware>
-        <firmware compare="regex" version="MPK03.0[0-1]_*">paired device</firmware>
-        <firmware compare="regex" version="MPK04.00_*">paired device</firmware>
-      </incompatibilities>
     </release>
   </releases>
 
@@ -43,6 +36,11 @@
   <requires>
     <id compare="ge" version="1.0.3">org.freedesktop.fwupd</id>
     <firmware compare="regex" version="BOT03.0[2-9]_*">bootloader</firmware>
+    <firmware compare="regex" version="RQK62.00_*">not-child</firmware>
+    <firmware compare="regex" version="RQK63.0[01]_*">not-child</firmware>
+    <firmware compare="regex" version="MPK01.0[0-2]_*">not-child</firmware>
+    <firmware compare="regex" version="MPK03.0[0-1]_*">not-child</firmware>
+    <firmware compare="regex" version="MPK04.00_*">not-child</firmware>
   </requires>
 
 </component>

--- a/RQR24/RQR24.07/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.07/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -29,6 +29,13 @@
           First release for signed DFU, otherwise identical to RQR24.06_B0030.
         </p>
       </description>
+      <incompatibilities>
+        <firmware compare="regex" version="RQK62.00_*">paired device</firmware>
+        <firmware compare="regex" version="RQK63.0[01]_*">paired device</firmware>
+        <firmware compare="regex" version="MPK01.0[0-2]_*">paired device</firmware>
+        <firmware compare="regex" version="MPK03.0[0-1]_*">paired device</firmware>
+        <firmware compare="regex" version="MPK04.00_*">paired device</firmware>
+      </incompatibilities>
     </release>
   </releases>
 


### PR DESCRIPTION
Incompatibility (pre-requisite) handling:

 - Incompatible firmware versions are listed in the "requires" tag's
   content.  Rationale: since compatibility should be the rule and
   incompatibility should be the exception, the tag lists incompatible
   firmware only.
 - Incompatibile firmware versions are listed in "firmware" tags, with a
   version typically given as regular expression.
 - The content of each "firmware" is "not-child", if a receiver is
   incompatible with a wireless device or "not-parent" if a wireless
   device is incompatible with a receiver (currently, only the former
   exists at Logitech).
    - In the former case, all wireless devices must be upgraded (with
      a compatible firmware) before the receiver.
    - In the latter case, the receiver must be upgraded (with a
      compatible firmware) before the wireless devices.
