### PR TITLE
Add boot-loader requirement for all firmware

### DIFF
--- a/MPK01/MPK01.02/lvfs/com.logitech.MPK01.metainfo.xml
+++ b/MPK01/MPK01.02/lvfs/com.logitech.MPK01.metainfo.xml
@@ -33,5 +33,6 @@
   <!-- only newer versions of fwupd know how to write to this hardware -->
   <requires>
     <id compare="ge" version="0.9.5">org.freedesktop.fwupd</id>
+    <firmware compare="regex" version="BOT25.*">bootloader</firmware>
   </requires>
 </component>

--- a/MPK01/MPK01.03/lvfs/com.logitech.MPK01.metainfo.xml
+++ b/MPK01/MPK01.03/lvfs/com.logitech.MPK01.metainfo.xml
@@ -33,5 +33,6 @@
   <!-- only newer versions of fwupd know how to write to this hardware -->
   <requires>
     <id compare="ge" version="0.9.5">org.freedesktop.fwupd</id>
+    <firmware compare="regex" version="BOT25.*">bootloader</firmware>
   </requires>
 </component>

--- a/MPK03/MPK03.02/lvfs/com.logitech.MPK03.metainfo.xml
+++ b/MPK03/MPK03.02/lvfs/com.logitech.MPK03.metainfo.xml
@@ -34,6 +34,7 @@
   <!-- only newer versions of fwupd know how to write to this hardware -->
   <requires>
     <id compare="ge" version="0.9.5">org.freedesktop.fwupd</id>
+    <firmware compare="regex" version="BOT42.*">bootloader</firmware>
   </requires>
 
 </component>

--- a/MPK04/MPK04.01/lvfs/com.logitech.MPK04.metainfo.xml
+++ b/MPK04/MPK04.01/lvfs/com.logitech.MPK04.metainfo.xml
@@ -33,6 +33,7 @@
   <!-- only newer versions of fwupd know how to write to this hardware -->
   <requires>
     <id compare="ge" version="0.9.5">org.freedesktop.fwupd</id>
+    <firmware compare="regex" version="BOT43.*">bootloader</firmware>
   </requires>
 
 </component>

--- a/RQK62/RQK62.01/lvfs/com.logitech.RQK62.metainfo.xml
+++ b/RQK62/RQK62.01/lvfs/com.logitech.RQK62.metainfo.xml
@@ -33,6 +33,7 @@
   <!-- This requires the version of fwupd that supports manual restart of device -->
   <requires>
     <id compare="ge" version="1.0.3">org.freedesktop.fwupd</id>
+    <firmware compare="regex" version="BOT21.*">bootloader</firmware>
   </requires>
 
 </component>

--- a/RQK63/RQK63.02/lvfs/com.logitech.RQK63.metainfo.xml
+++ b/RQK63/RQK63.02/lvfs/com.logitech.RQK63.metainfo.xml
@@ -33,6 +33,7 @@
   <!-- only newer versions of fwupd know how to write to this hardware -->
   <requires>
     <id compare="ge" version="0.9.5">org.freedesktop.fwupd</id>
+    <firmware compare="regex" version="BOT22.*">bootloader</firmware>
   </requires>
 
 </component>


### PR DESCRIPTION
This has the added benefit to recognize compatible FW when a device is
"stuck" in boot-loader.