### PR TITLE
Add LVFS::UpdateProtocol to existing firmware

### DIFF
--- a/MPK01/MPK01.02/lvfs/com.logitech.MPK01.metainfo.xml
+++ b/MPK01/MPK01.02/lvfs/com.logitech.MPK01.metainfo.xml
@@ -35,4 +35,8 @@
     <id compare="ge" version="0.9.5">org.freedesktop.fwupd</id>
     <firmware compare="regex" version="BOT25.*">bootloader</firmware>
   </requires>
+  <custom>
+    <value key="LVFS::UpdateProtocol">com.logitech.unifying</value>
+  </custom>
+
 </component>

--- a/MPK01/MPK01.03/lvfs/com.logitech.MPK01.metainfo.xml
+++ b/MPK01/MPK01.03/lvfs/com.logitech.MPK01.metainfo.xml
@@ -35,4 +35,8 @@
     <id compare="ge" version="0.9.5">org.freedesktop.fwupd</id>
     <firmware compare="regex" version="BOT25.*">bootloader</firmware>
   </requires>
+  <custom>
+    <value key="LVFS::UpdateProtocol">com.logitech.unifying</value>
+  </custom>
+
 </component>

--- a/MPK03/MPK03.02/lvfs/com.logitech.MPK03.metainfo.xml
+++ b/MPK03/MPK03.02/lvfs/com.logitech.MPK03.metainfo.xml
@@ -37,4 +37,8 @@
     <firmware compare="regex" version="BOT42.*">bootloader</firmware>
   </requires>
 
+  <custom>
+    <value key="LVFS::UpdateProtocol">com.logitech.unifying</value>
+  </custom>
+
 </component>

--- a/MPK04/MPK04.01/lvfs/com.logitech.MPK04.metainfo.xml
+++ b/MPK04/MPK04.01/lvfs/com.logitech.MPK04.metainfo.xml
@@ -36,4 +36,8 @@
     <firmware compare="regex" version="BOT43.*">bootloader</firmware>
   </requires>
 
+  <custom>
+    <value key="LVFS::UpdateProtocol">com.logitech.unifying</value>
+  </custom>
+
 </component>

--- a/RQK62/RQK62.01/lvfs/com.logitech.RQK62.metainfo.xml
+++ b/RQK62/RQK62.01/lvfs/com.logitech.RQK62.metainfo.xml
@@ -36,4 +36,8 @@
     <firmware compare="regex" version="BOT21.*">bootloader</firmware>
   </requires>
 
+  <custom>
+    <value key="LVFS::UpdateProtocol">com.logitech.unifying</value>
+  </custom>
+
 </component>

--- a/RQK63/RQK63.02/lvfs/com.logitech.RQK63.metainfo.xml
+++ b/RQK63/RQK63.02/lvfs/com.logitech.RQK63.metainfo.xml
@@ -36,4 +36,8 @@
     <firmware compare="regex" version="BOT22.*">bootloader</firmware>
   </requires>
 
+  <custom>
+    <value key="LVFS::UpdateProtocol">com.logitech.unifying</value>
+  </custom>
+
 </component>

--- a/RQR12/RQR12.05/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.05/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -45,4 +45,8 @@
     <firmware compare="regex" version="BOT01.0[0-3]_*">bootloader</firmware>
   </requires>
 
+  <custom>
+    <value key="LVFS::UpdateProtocol">com.logitech.unifying</value>
+  </custom>
+
 </component>

--- a/RQR12/RQR12.07/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.07/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -45,4 +45,8 @@
     <firmware compare="regex" version="BOT01.0[0-3]_*">bootloader</firmware>
   </requires>
 
+  <custom>
+    <value key="LVFS::UpdateProtocol">com.logitech.unifying</value>
+  </custom>
+
 </component>

--- a/RQR12/RQR12.08/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.08/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -64,4 +64,8 @@
     <firmware compare="regex" version="MPK04.00_*">not-child</firmware>
   </requires>
 
+  <custom>
+    <value key="LVFS::UpdateProtocol">com.logitech.unifying</value>
+  </custom>
+
 </component>

--- a/RQR12/RQR12.09/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.09/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -43,4 +43,8 @@
     <firmware compare="regex" version="MPK04.00_*">not-child</firmware>
   </requires>
 
+  <custom>
+    <value key="LVFS::UpdateProtocol">com.logitech.unifyingsigned</value>
+  </custom>
+
 </component>

--- a/RQR24/RQR24.03/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.03/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -44,4 +44,8 @@
     <firmware compare="regex" version="BOT03.0[0-1]_*">bootloader</firmware>
   </requires>
 
+  <custom>
+    <value key="LVFS::UpdateProtocol">com.logitech.unifying</value>
+  </custom>
+
 </component>

--- a/RQR24/RQR24.05/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.05/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -44,4 +44,8 @@
     <firmware compare="regex" version="BOT03.0[0-1]_*">bootloader</firmware>
   </requires>
 
+  <custom>
+    <value key="LVFS::UpdateProtocol">com.logitech.unifying</value>
+  </custom>
+
 </component>

--- a/RQR24/RQR24.06/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.06/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -64,4 +64,8 @@
     <firmware compare="regex" version="MPK04.00_*">not-child</firmware>
   </requires>
 
+  <custom>
+    <value key="LVFS::UpdateProtocol">com.logitech.unifying</value>
+  </custom>
+
 </component>

--- a/RQR24/RQR24.07/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.07/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -43,4 +43,8 @@
     <firmware compare="regex" version="MPK04.00_*">not-child</firmware>
   </requires>
 
+  <custom>
+    <value key="LVFS::UpdateProtocol">com.logitech.unifyingsigned</value>
+  </custom>
+
 </component>


### PR DESCRIPTION
While not strictly required, it means any future firmware that is copy+pasted
from an existing version has the correct metadata.

See https://fwupd.org/lvfs/docs/metainfo/protocol for the documentation.