### PR TITLE
Fix release descriptions for two LVFS files

### DIFF
--- a/RQR12/RQR12.08/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.08/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -33,19 +33,22 @@
           to be physically close to a target.
         </p>
         <p>
-          A few of Logitech's devices:
-          <ul>
-            <li>Wireless Mouse M335</li>
-            <li>Zone Touch Mouse T400</li>
-            <li>Wireless Mouse M545</li>
-            <li>Wireless Mouse M560</li>
-            <li>Touch Mouse M600</li>
-            <li>Touch Mouse T620</li>
-            <li>Wireless Rechargeable Touchpad T650</li>
-          </ul>
-          used to send select buttons in an unencrypted way, and in an effort
-          to protect against this vulnerability, Logitech removed the
-          feature.  Although Logitech does not recommend it, these features
+          A few of Logitech's devices used to send select buttons in an
+          unencrypted way, and in an effort to protect against this
+          vulnerability, Logitech removed the feature.
+          Affected hardware is:
+        </p>
+        <ul>
+          <li>Wireless Mouse M335</li>
+          <li>Zone Touch Mouse T400</li>
+          <li>Wireless Mouse M545</li>
+          <li>Wireless Mouse M560</li>
+          <li>Touch Mouse M600</li>
+          <li>Touch Mouse T620</li>
+          <li>Wireless Rechargeable Touchpad T650</li>
+        </ul>
+        <p>
+          Although Logitech does not recommend it, these features
           may be re-activated by keeping/downgrading the receiver to an older
           firmware.
         </p>

--- a/RQR24/RQR24.06/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.06/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -33,19 +33,22 @@
           to be physically close to a target.
         </p>
         <p>
-          A few of Logitech's devices:
-          <ul>
-            <li>Wireless Mouse M335</li>
-            <li>Zone Touch Mouse T400</li>
-            <li>Wireless Mouse M545</li>
-            <li>Wireless Mouse M560</li>
-            <li>Touch Mouse M600</li>
-            <li>Touch Mouse T620</li>
-            <li>Wireless Rechargeable Touchpad T650</li>
-          </ul>
-          used to send select buttons in an unencrypted way, and in an effort
-          to protect against this vulnerability, Logitech removed the
-          feature.  Although Logitech does not recommend it, these features
+          A few of Logitech's devices used to send select buttons in an
+          unencrypted way, and in an effort to protect against this
+          vulnerability, Logitech removed the feature.
+          Affected hardware is:
+        </p>
+        <ul>
+          <li>Wireless Mouse M335</li>
+          <li>Zone Touch Mouse T400</li>
+          <li>Wireless Mouse M545</li>
+          <li>Wireless Mouse M560</li>
+          <li>Touch Mouse M600</li>
+          <li>Touch Mouse T620</li>
+          <li>Wireless Rechargeable Touchpad T650</li>
+        </ul>
+        <p>
+          Although Logitech does not recommend it, these features
           may be re-activated by keeping/downgrading the receiver to an older
           firmware.
         </p>


### PR DESCRIPTION
The lists cannot be nested in paragraphs, and both `fwupdmgr install` and
`appstream-util validate --relax *.xml` fail...