### PR TITLE
Add the LVFS category metadata to all metadata files

### DIFF
--- a/MPK01/MPK01.02/lvfs/com.logitech.MPK01.metainfo.xml
+++ b/MPK01/MPK01.02/lvfs/com.logitech.MPK01.metainfo.xml
@@ -29,6 +29,9 @@
       </description>
     </release>
   </releases>
+  <categories>
+    <category>X-Device</category>
+  </categories>
 
   <!-- only newer versions of fwupd know how to write to this hardware -->
   <requires>

--- a/MPK01/MPK01.03/lvfs/com.logitech.MPK01.metainfo.xml
+++ b/MPK01/MPK01.03/lvfs/com.logitech.MPK01.metainfo.xml
@@ -29,6 +29,9 @@
       </description>
     </release>
   </releases>
+  <categories>
+    <category>X-Device</category>
+  </categories>
 
   <!-- only newer versions of fwupd know how to write to this hardware -->
   <requires>

--- a/MPK03/MPK03.02/lvfs/com.logitech.MPK03.metainfo.xml
+++ b/MPK03/MPK03.02/lvfs/com.logitech.MPK03.metainfo.xml
@@ -30,6 +30,9 @@
       </description>
     </release>
   </releases>
+  <categories>
+    <category>X-Device</category>
+  </categories>
 
   <!-- only newer versions of fwupd know how to write to this hardware -->
   <requires>

--- a/MPK04/MPK04.01/lvfs/com.logitech.MPK04.metainfo.xml
+++ b/MPK04/MPK04.01/lvfs/com.logitech.MPK04.metainfo.xml
@@ -29,6 +29,9 @@
       </description>
     </release>
   </releases>
+  <categories>
+    <category>X-Device</category>
+  </categories>
 
   <!-- only newer versions of fwupd know how to write to this hardware -->
   <requires>

--- a/RQK62/RQK62.01/lvfs/com.logitech.RQK62.metainfo.xml
+++ b/RQK62/RQK62.01/lvfs/com.logitech.RQK62.metainfo.xml
@@ -29,6 +29,9 @@
       </description>
     </release>
   </releases>
+  <categories>
+    <category>X-Device</category>
+  </categories>
 
   <!-- This requires the version of fwupd that supports manual restart of device -->
   <requires>

--- a/RQK63/RQK63.02/lvfs/com.logitech.RQK63.metainfo.xml
+++ b/RQK63/RQK63.02/lvfs/com.logitech.RQK63.metainfo.xml
@@ -29,6 +29,9 @@
       </description>
     </release>
   </releases>
+  <categories>
+    <category>X-Device</category>
+  </categories>
 
   <!-- only newer versions of fwupd know how to write to this hardware -->
   <requires>

--- a/RQR12/RQR12.05/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.05/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -38,6 +38,9 @@
       </description>
     </release>
   </releases>
+  <categories>
+    <category>X-Device</category>
+  </categories>
 
   <!-- only newer versions of fwupd know how to write to this hardware -->
   <requires>

--- a/RQR12/RQR12.07/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.07/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -38,6 +38,9 @@
       </description>
     </release>
   </releases>
+  <categories>
+    <category>X-Device</category>
+  </categories>
 
   <!-- only newer versions of fwupd know how to write to this hardware -->
   <requires>

--- a/RQR12/RQR12.08/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.08/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -55,6 +55,9 @@
       </description>
     </release>
   </releases>
+  <categories>
+    <category>X-Device</category>
+  </categories>
 
   <!-- only newer versions of fwupd know how to write to this hardware -->
   <requires>

--- a/RQR12/RQR12.09/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.09/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -31,6 +31,9 @@
       </description>
     </release>
   </releases>
+  <categories>
+    <category>X-Device</category>
+  </categories>
 
   <!-- requires fwupd version that knows how to write signed firmware -->
   <requires>

--- a/RQR24/RQR24.03/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.03/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -37,6 +37,9 @@
       </description>
     </release>
   </releases>
+  <categories>
+    <category>X-Device</category>
+  </categories>
 
   <!-- only newer versions of fwupd know how to write to this hardware -->
   <requires>

--- a/RQR24/RQR24.05/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.05/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -37,6 +37,9 @@
       </description>
     </release>
   </releases>
+  <categories>
+    <category>X-Device</category>
+  </categories>
 
   <!-- only newer versions of fwupd know how to write to this hardware -->
   <requires>

--- a/RQR24/RQR24.06/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.06/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -55,6 +55,9 @@
       </description>
     </release>
   </releases>
+  <categories>
+    <category>X-Device</category>
+  </categories>
 
   <!-- only newer versions of fwupd know how to write to this hardware -->
   <requires>

--- a/RQR24/RQR24.07/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.07/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -31,6 +31,9 @@
       </description>
     </release>
   </releases>
+  <categories>
+    <category>X-Device</category>
+  </categories>
 
   <!-- requires fwupd version that knows how to write signed firmware -->
   <requires>


### PR DESCRIPTION
The X-Device category tells the LVFS and front end UI that this is a single
device update and not a system update and helps us present the update in the
correct way.