### PR TITLE
Add a tag to disambiguate firmware with the same name

### DIFF
--- a/RQR12/RQR12.05/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.05/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -3,6 +3,7 @@
 <component type="firmware">
   <id>com.logitech.Unifying.RQR12.firmware</id>
   <name>Logitech Unifying Receiver</name>
+  <name_variant_suffix>RQR12</name_variant_suffix>
   <summary>Firmware for the Logitech Unifying receiver</summary>
   <description>
     <p>

--- a/RQR12/RQR12.07/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.07/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -3,6 +3,7 @@
 <component type="firmware">
   <id>com.logitech.Unifying.RQR12.firmware</id>
   <name>Logitech Unifying Receiver</name>
+  <name_variant_suffix>RQR12</name_variant_suffix>
   <summary>Firmware for the Logitech Unifying receiver</summary>
   <description>
     <p>

--- a/RQR12/RQR12.08/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.08/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -3,6 +3,7 @@
 <component type="firmware">
   <id>com.logitech.Unifying.RQR12.firmware</id>
   <name>Logitech Unifying Receiver</name>
+  <name_variant_suffix>RQR12</name_variant_suffix>
   <summary>Firmware for the Logitech Unifying receiver</summary>
   <description>
     <p>

--- a/RQR12/RQR12.09/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
+++ b/RQR12/RQR12.09/lvfs/com.logitech.Unifying.RQR12.metainfo.xml
@@ -3,6 +3,7 @@
 <component type="firmware">
   <id>com.logitech.Unifying.RQR12.signed.firmware</id>
   <name>Logitech Unifying Receiver</name>
+  <name_variant_suffix>Signed RQR12</name_variant_suffix>
   <summary>Firmware for the Logitech Unifying receiver</summary>
   <description>
     <p>

--- a/RQR24/RQR24.03/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.03/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -3,6 +3,7 @@
 <component type="firmware">
   <id>com.logitech.Unifying.RQR24.firmware</id>
   <name>Logitech Unifying Receiver</name>
+  <name_variant_suffix>RQR24</name_variant_suffix>
   <summary>Firmware for the Logitech Unifying receiver</summary>
   <description>
     <p>

--- a/RQR24/RQR24.05/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.05/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -3,6 +3,7 @@
 <component type="firmware">
   <id>com.logitech.Unifying.RQR24.firmware</id>
   <name>Logitech Unifying Receiver</name>
+  <name_variant_suffix>RQR24</name_variant_suffix>
   <summary>Firmware for the Logitech Unifying receiver</summary>
   <description>
     <p>

--- a/RQR24/RQR24.06/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.06/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -3,6 +3,7 @@
 <component type="firmware">
   <id>com.logitech.Unifying.RQR24.firmware</id>
   <name>Logitech Unifying Receiver</name>
+  <name_variant_suffix>RQR24</name_variant_suffix>
   <summary>Firmware for the Logitech Unifying receiver</summary>
   <description>
     <p>

--- a/RQR24/RQR24.07/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
+++ b/RQR24/RQR24.07/lvfs/com.logitech.Unifying.RQR24.metainfo.xml
@@ -3,6 +3,7 @@
 <component type="firmware">
   <id>com.logitech.Unifying.RQR24.signed.firmware</id>
   <name>Logitech Unifying Receiver</name>
+  <name_variant_suffix>Signed RQR24</name_variant_suffix>
   <summary>Firmware for the Logitech Unifying receiver</summary>
   <description>
     <p>


### PR DESCRIPTION
This optional tag isn't useful for most vendors or most devices, and is only
useful in the case where there are multiple variants of a device with a
different <id> and the same <name>.

The suffix is appended to the name in brackets when required, so that there are
not two "identical" names in https://www.fwupd.org/lvfs/devicelist